### PR TITLE
이메일 중복, 패스워드 중북 요청의 url을 수정

### DIFF
--- a/src/data/http/member-api.ts
+++ b/src/data/http/member-api.ts
@@ -52,7 +52,7 @@ export class MemberApiProvider {
       return await this.axiosWrapper
         .getAxios()
         .get(
-          process.env.REACT_APP_HOST + "members/validate/memberid/" + memberId
+          process.env.REACT_APP_HOST + "/members/validate/memberid/" + memberId
         );
     } catch (error) {
       throw error;
@@ -64,7 +64,7 @@ export class MemberApiProvider {
       return await this.axiosWrapper
         .getAxios()
         .get(
-          process.env.REACT_APP_HOST + "members/validate/nickname/" + nickName
+          process.env.REACT_APP_HOST + "/members/validate/nickname/" + nickName
         );
     } catch (error) {
       throw error;


### PR DESCRIPTION
**내용**
요청 주소 오류가 났기 때문에 요청 url을 올바르게 수정함
- "/" 하나가 빠져 있었다.

**차 후 수정할일**
- 요청 url 상수화( enum )

close #44