### PR TITLE
화면에 버튼을 클릭했을 시 시간을 보여주는 ui가 2~3초 딜레이 되던 부분을 수정

### DIFF
--- a/src/presentation/molecule/digital-clock/index.tsx
+++ b/src/presentation/molecule/digital-clock/index.tsx
@@ -32,7 +32,7 @@ export const DigitalClock: React.FC<{ color: string }> = ({ color }) => {
   React.useEffect(() => {
     const setTime = setInterval(changeTime, 1000);
     return () => clearInterval(setTime);
-  });
+  }, []);
   return (
     <styled.Clock color={color}>
       <div className={"hours"}>


### PR DESCRIPTION
react의 hook인 useEffect에서 interval을 이용한 시간 보여주기 기능을 선언하고 화면에 나갈때는 메모리를 해제하도록 구현 하였다.

하지만 이 useEffect는 state가 바뀔 때마다 실행이 되기 때문에 interval이 해제되고 다시 생성되는 과정을 거치기 때문에 딜레이가 발생하였다.

때문에 이 useEffect가 한 번만 실행하여 화면 안에 있다면 state가 바뀌어도 interval이 해제되지 않게 하였고 이 화면에 나갈 때만 interval을 해제하도록 하였다.


관련 #54
close #57