### PR TITLE
Feature/issue 110

### DIFF
--- a/src/data/repository/member-repository-impl.ts
+++ b/src/data/repository/member-repository-impl.ts
@@ -70,11 +70,6 @@ export class MemberRepositoryImpl implements MemberRepository {
           false,
           PublicErrorMessage.REQUEST_FAIL
         );
-      if (error.response.data.code === AuthErrorCode.EMAIL_AUTH_PENDING)
-        return new RepoResponseType<undefined>(
-          false,
-          AuthErrorMessage.EMAIL_AUTH_PENDING
-        );
       return new RepoResponseType<undefined>(
         false,
         PublicErrorMessage.UNKNOWN_ERROR

--- a/src/enum/auth-error-code.ts
+++ b/src/enum/auth-error-code.ts
@@ -1,4 +1,3 @@
 export enum AuthErrorCode {
   NOT_USER = "AUT001",
-  EMAIL_AUTH_PENDING = "AUT002",
 }

--- a/src/enum/auth-error-message.ts
+++ b/src/enum/auth-error-message.ts
@@ -1,5 +1,4 @@
 export enum AuthErrorMessage {
   NOT_USER = "인증 오류",
-  EMAIL_AUTH_PENDING = "이메일 인증이 아직 되지 않은 아이디입니다. 이메일 인증 부탁드립니다.",
   NOT_COME_TOKEN = "인증에 실패 하셨습니다. 잠시 후 다시 로그인해 주세요.",
 }

--- a/src/presentation/page/login/login-then-password.tsx
+++ b/src/presentation/page/login/login-then-password.tsx
@@ -58,12 +58,6 @@ export const LoginThenPassword: React.FC = () => {
       }
       setResultModalText(result.message);
       resultModalEvent.addClickOutSideEvent();
-      if (result.message === AuthErrorMessage.EMAIL_AUTH_PENDING) {
-        setResultModalTitle("로그인에 실패하였습니다.");
-        setResultModalAction(AuthErrorCode.EMAIL_AUTH_PENDING);
-        setResultModalOnoff(1);
-        return;
-      }
       setResultModalTitle("로그인에 실패하였습니다.");
       setResultModalAction(AuthErrorCode.NOT_USER);
       setResultModalOnoff(1);
@@ -76,11 +70,6 @@ export const LoginThenPassword: React.FC = () => {
   ) => {
     event.preventDefault();
     switch (resultModalAction) {
-      case AuthErrorCode.EMAIL_AUTH_PENDING:
-        resultModalEvent.removeClickOutSideEvent(event);
-        setResultModalOnoff(0);
-        Application.services.member.sendEmail(email);
-        return history.push("/codecheck/" + email);
       case AuthErrorCode.NOT_USER:
         resultModalEvent.removeClickOutSideEvent(event);
         return setResultModalOnoff(0);


### PR DESCRIPTION
### Contents
- 로그인 시 이메일 인증 여부 확인 로직 삭제

### WHY
- 로그인과 이메일 인증의 로직 분리


**resolve/fix/close** : #110
